### PR TITLE
Added integration with private S3 buckets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,45 @@
-FROM nginx:1.17-alpine
+# Copyright (C) 2020  Axel Amigo Arnold
 
-ARG S3_BUCKET=a-bucket-name.s3.amazonaws.com
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+FROM openresty/openresty:buster
+
+ARG S3_BUCKET_NAME=a-bucket-name
 ARG SECRET
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
+ARG BUCKET_REGION=us-east-1
 
-COPY nginx-cache-path.conf /etc/nginx/conf.d/nginx-cache-path.conf
+
+# Copy required files
+
+## NGINX
 COPY nginx-site-example.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 
-RUN sed -i s/your-bucket/$S3_BUCKET/g /etc/nginx/conf.d/default.conf
+## Openresty
+COPY lib/aws.lua /usr/local/openresty/lualib/resty/aws.lua
+COPY lib/hmac.lua /usr/local/openresty/lualib/resty/hmac.lua
+
+
+# Perform modifications based on arguments
+
+## Site
+RUN sed -i s/your-bucket-name/$S3_BUCKET_NAME/g /etc/nginx/conf.d/default.conf
+RUN sed -i s/your-bucket-region/$BUCKET_REGION/g /etc/nginx/conf.d/default.conf
 RUN sed -i s/AM1ghtyS3cr3t\!/$SECRET/g /etc/nginx/conf.d/default.conf
+
+## NGINX global config
+RUN sed -i s/INVALID_AWS_ACCESS_KEY_ID/$AWS_ACCESS_KEY_ID/g /usr/local/openresty/nginx/conf/nginx.conf
+RUN sed -i s/INVALID_AWS_SECRET_ACCESS_KEY/$AWS_SECRET_ACCESS_KEY/g /usr/local/openresty/nginx/conf/nginx.conf

--- a/README.md
+++ b/README.md
@@ -3,26 +3,55 @@ Serve files securely from an S3 bucket with expiring links and other restriction
 
 ## WIP list
 
-- Be able to use Private S3 buckets
-- Be able to change the `/s` and `/s/cached` URIs
+- Be able to change the `/s` URIs
 - Improve docs
 - Allow links to be created without client IP restriction
 - Allow links to be created without time expiration
+- Limit the amount of downloads per IP address
+- ~~Be able to use Private S3 buckets~~
+
 
 
 ## Building the image
 
-`docker build --build-arg SECRET=CHANGEMEforducksake --build-arg S3_BUCKET=a-public-bucket.s3.amazonaws.com -t wh03v3r/s3cr3t-server .`
+```
+ export AWS_ACCESS_KEY_ID=1234
+ export AWS_SECRET_ACCESS_KEY=5678
+ export SECRET=CHANGEMEforducksake
+ export S3_BUCKET_NAME=your-bucket
+ export BUCKET_REGION=us-east-1
+
+docker build \
+--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+--build-arg SECRET=$SECRET \
+--build-arg S3_BUCKET_NAME=$S3_BUCKET_NAME \
+--build-arg BUCKET_REGION=$BUCKET_REGION \
+-t s3cr3t/s3cr3t-server .
+```
 
 ## Getting a link
 
-If the `-e` argument is not specified, the link will have a default duration of 1h.
+### Installing prerequisites
 
-### Without cache
+```
+apt update && apt install python3 python3-pip -y
+pip3 install -r requirements.txt
+```
 
-`./link-generator-example.py -p /s/oneregularfile.tar.gz -r 172.17.0.1 -h http://localhost:9090 -s CHANGEMEforducksake`
+### Using the secret-link-generator utility
 
 
-### With cache
+```
+./secret-link-generator.py \
+-p /s/oneregularfile.tar.gz \
+-r 172.17.0.1 \
+-h http://localhost:9090 \
+-s CHANGEMEforducksake
+```
 
-`./link-generator-example.py -p /s/cached/oneregularfile.tar.gz -r 172.17.0.1 -h http://localhost:9090 -s CHANGEMEforducksake`
+Will return:
+
+`http://localhost:9090/s/oneregularfile.tar.gz?md5=v-qpUxhRuDeNVTdFQzTfhA&expires=1584897454`
+
+__Warning__: If the `-e` argument is not specified, the link will have a default duration of 1h.

--- a/lib/aws.lua
+++ b/lib/aws.lua
@@ -1,0 +1,171 @@
+--[[
+    Copyright (C) 2020  Axel Amigo Arnold
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+--]]
+
+local cjson = require 'cjson'
+local resty_hmac = require 'resty.hmac'
+local resty_sha256 = require 'resty.sha256'
+local str = require 'resty.string'
+
+local setmetatable = setmetatable
+local error = error
+
+local _M = { _VERSION = '0.1.0' }
+local mt = { __index = _M }
+
+local function get_credentials ()
+  local access_key = os.getenv('AWS_ACCESS_KEY_ID')
+  local secret_key = os.getenv('AWS_SECRET_ACCESS_KEY')
+  if access_key ~= nil and secret_key ~= nil then
+    return {
+      access_key = access_key,
+      secret_key = secret_key
+    }
+  end
+
+  local res = ngx.location.capture('/_meta-data/iam/security-credentials/')
+  if res.status ~= ngx.HTTP_OK then
+    return
+  end
+
+  res = ngx.location.capture('/_meta-data/iam/security-credentials/' .. res.body)
+  if res.status ~= ngx.HTTP_OK then
+    return
+  end
+
+  local creds = cjson.decode(res.body)
+  if creds['Type'] ~= 'AWS-HMAC' or creds['Code'] ~= 'Success' then
+    return
+  end
+
+  return {
+    access_key = creds['AccessKeyId'],
+    secret_key = creds['SecretAccessKey'],
+    security_token = creds['Token']
+  }
+end
+
+local function get_iso8601_basic(timestamp)
+  return os.date('!%Y%m%dT%H%M%SZ', timestamp)
+end
+
+local function get_iso8601_basic_short(timestamp)
+  return os.date('!%Y%m%d', timestamp)
+end
+local function get_cred_scope(timestamp, region, service)
+  return get_iso8601_basic_short(timestamp)
+    .. '/' .. region
+    .. '/' .. service
+    .. '/aws4_request'
+end
+
+local function get_signed_headers()
+  return 'host;x-amz-content-sha256;x-amz-date'
+end
+
+local function get_sha256_digest(s)
+  local h = resty_sha256:new()
+  h:update(s or '')
+  return str.to_hex(h:final())
+end
+
+local function get_hashed_canonical_request(timestamp, host, uri)
+  local digest = get_sha256_digest(ngx.var.request_body)
+  local canonical_request = ngx.var.request_method .. '\n'
+    .. uri .. '\n'
+    .. '\n'
+    .. 'host:' .. host .. '\n'
+    .. 'x-amz-content-sha256:' .. digest .. '\n'
+    .. 'x-amz-date:' .. get_iso8601_basic(timestamp) .. '\n'
+    .. '\n'
+    .. get_signed_headers() .. '\n'
+    .. digest
+  return get_sha256_digest(canonical_request)
+end
+
+local function get_string_to_sign(timestamp, region, service, host, uri)
+  return 'AWS4-HMAC-SHA256\n'
+    .. get_iso8601_basic(timestamp) .. '\n'
+    .. get_cred_scope(timestamp, region, service) .. '\n'
+    .. get_hashed_canonical_request(timestamp, host, uri)
+end
+
+local function hmac_sha256_digest(key, content, hex_output)
+  return resty_hmac:new(key, resty_hmac.ALGOS.SHA256):final(content, hex_output)
+end
+
+local function hmac_sha256_hexdigest(key, content)
+  return hmac_sha256_digest(key, content, true)
+end
+
+local function get_derived_signing_key(keys, timestamp, region, service)
+  local k_date = hmac_sha256_digest('AWS4' .. keys['secret_key'], get_iso8601_basic_short(timestamp))
+  local k_region = hmac_sha256_digest(k_date, region)
+  local k_service = hmac_sha256_digest(k_region, service)
+  return hmac_sha256_digest(k_service, 'aws4_request')
+end
+
+local function get_authorization(keys, timestamp, region, service, host, uri)
+  local derived_signing_key = get_derived_signing_key(keys, timestamp, region, service)
+  local string_to_sign = get_string_to_sign(timestamp, region, service, host, uri)
+  local auth = 'AWS4-HMAC-SHA256 '
+    .. 'Credential=' .. keys['access_key'] .. '/' .. get_cred_scope(timestamp, region, service)
+    .. ', SignedHeaders=' .. get_signed_headers()
+    .. ', Signature=' .. hmac_sha256_hexdigest(derived_signing_key, string_to_sign)
+  return auth
+end
+
+local function get_service_and_region(host)
+  local patterns = {
+    {'s3.amazonaws.com', 's3', 'us-east-1'},
+    {'s3-external-1.amazonaws.com', 's3', 'us-east-1'},
+    {'s3%-([a-z0-9-]+)%.amazonaws%.com', 's3', nil},
+    {'s3%.([a-z0-9-]+)%.amazonaws%.com', 's3', nil}
+  }
+  for i,data in ipairs(patterns) do
+    local region = host:match(data[1])
+    if region ~= nil and data[3] == nil then
+      return data[2], region
+    elseif region ~= nil then
+      return data[2], data[3]
+    end
+  end
+  return nil, nil
+end
+
+local function aws_set_headers(host, uri)
+  local creds = get_credentials()
+  local timestamp = tonumber(ngx.time())
+  local service, region = get_service_and_region(host)
+  local auth = get_authorization(creds, timestamp, region, service, host, uri)
+
+  ngx.req.set_header('Authorization', auth)
+  ngx.req.set_header('Host', host)
+  ngx.req.set_header('x-amz-date', get_iso8601_basic(timestamp))
+  if creds['security_token'] ~= nil then
+    ngx.req.set_header('x-amz-security-token', creds['security_token'])
+  end
+end
+
+local function s3_set_headers(host, uri)
+  aws_set_headers(host, uri)
+  ngx.req.set_header('x-amz-content-sha256', get_sha256_digest(ngx.var.request_body))
+end
+
+_M.aws_set_headers = aws_set_headers
+_M.s3_set_headers = s3_set_headers
+
+return _M

--- a/lib/hmac.lua
+++ b/lib/hmac.lua
@@ -1,0 +1,183 @@
+--[[
+    This module is licensed under the BSD license.
+
+    Copyright (C) 2012-2020, Thought Foundry Inc.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+]]
+
+local str_util = require "resty.string"
+local to_hex = str_util.to_hex
+local ffi = require "ffi"
+local ffi_new = ffi.new
+local ffi_str = ffi.string
+local ffi_gc = ffi.gc
+local ffi_typeof = ffi.typeof
+local C = ffi.C
+local setmetatable = setmetatable
+local error = error
+
+
+local _M = { _VERSION = '0.04' }
+
+local mt = { __index = _M }
+
+
+ffi.cdef[[
+typedef struct engine_st ENGINE;
+typedef struct evp_pkey_ctx_st EVP_PKEY_CTX;
+typedef struct evp_md_ctx_st EVP_MD_CTX;
+typedef struct evp_md_st EVP_MD;
+typedef struct hmac_ctx_st HMAC_CTX;
+
+//OpenSSL 1.0
+void HMAC_CTX_init(HMAC_CTX *ctx);
+void HMAC_CTX_cleanup(HMAC_CTX *ctx);
+
+//OpenSSL 1.1
+HMAC_CTX *HMAC_CTX_new(void);
+void HMAC_CTX_free(HMAC_CTX *ctx);
+
+int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len, const EVP_MD *md, ENGINE *impl);
+int HMAC_Update(HMAC_CTX *ctx, const unsigned char *data, size_t len);
+int HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len);
+
+const EVP_MD *EVP_md5(void);
+const EVP_MD *EVP_sha1(void);
+const EVP_MD *EVP_sha256(void);
+const EVP_MD *EVP_sha512(void);
+]]
+
+local buf = ffi_new("unsigned char[64]")
+local res_len = ffi_new("unsigned int[1]")
+local hashes = {
+    MD5 = C.EVP_md5(),
+    SHA1 = C.EVP_sha1(),
+    SHA256 = C.EVP_sha256(),
+    SHA512 = C.EVP_sha512()
+}
+
+local ctx_new, ctx_free
+local openssl11, e = pcall(function ()
+    local ctx = C.HMAC_CTX_new()
+    C.HMAC_CTX_free(ctx)
+end)
+if openssl11 then
+    ctx_new = function ()
+        return C.HMAC_CTX_new()
+    end
+    ctx_free = function (ctx)
+        C.HMAC_CTX_free(ctx)
+    end
+else
+    ffi.cdef [[
+    struct evp_md_ctx_st
+    {
+        const EVP_MD *digest;
+        ENGINE *engine;
+        unsigned long flags;
+        void *md_data;
+        EVP_PKEY_CTX *pctx;
+        int (*update)(EVP_MD_CTX *ctx,const void *data,size_t count);
+    };
+
+    struct evp_md_st
+    {
+        int type;
+        int pkey_type;
+        int md_size;
+        unsigned long flags;
+        int (*init)(EVP_MD_CTX *ctx);
+        int (*update)(EVP_MD_CTX *ctx,const void *data,size_t count);
+        int (*final)(EVP_MD_CTX *ctx,unsigned char *md);
+        int (*copy)(EVP_MD_CTX *to,const EVP_MD_CTX *from);
+        int (*cleanup)(EVP_MD_CTX *ctx);
+
+        int (*sign)(int type, const unsigned char *m, unsigned int m_length, unsigned char *sigret, unsigned int *siglen, void *key);
+        int (*verify)(int type, const unsigned char *m, unsigned int m_length, const unsigned char *sigbuf, unsigned int siglen, void *key);
+        int required_pkey_type[5];
+        int block_size;
+        int ctx_size;
+        int (*md_ctrl)(EVP_MD_CTX *ctx, int cmd, int p1, void *p2);
+        };
+
+    struct hmac_ctx_st
+    {
+        const EVP_MD *md;
+        EVP_MD_CTX md_ctx;
+        EVP_MD_CTX i_ctx;
+        EVP_MD_CTX o_ctx;
+        unsigned int key_length;
+        unsigned char key[128];
+    };
+    ]]
+
+    local ctx_ptr_type = ffi_typeof("HMAC_CTX[1]")
+
+    ctx_new = function ()
+        local ctx = ffi_new(ctx_ptr_type)
+        C.HMAC_CTX_init(ctx)
+        return ctx
+    end
+    ctx_free = function (ctx) 
+        C.HMAC_CTX_cleanup(ctx)
+    end
+end
+
+
+_M.ALGOS = hashes
+
+
+function _M.new(self, key, hash_algo)
+    local ctx = ctx_new()
+
+    local _hash_algo = hash_algo or hashes.MD5
+
+    if C.HMAC_Init_ex(ctx, key, #key, _hash_algo, nil) == 0 then
+        return nil
+    end
+
+    ffi_gc(ctx, ctx_free)
+
+    return setmetatable({ _ctx = ctx }, mt)
+end
+
+
+function _M.update(self, s)
+    return C.HMAC_Update(self._ctx, s, #s) == 1
+end
+
+
+function _M.final(self, s, hex_output)
+
+    if s ~= nil then
+        if C.HMAC_Update(self._ctx, s, #s) == 0 then
+            return nil
+        end
+    end
+
+    if C.HMAC_Final(self._ctx, buf, res_len) == 1 then
+        if hex_output == true then
+            return to_hex(ffi_str(buf, res_len[0]))
+        end
+        return ffi_str(buf, res_len[0])
+    end
+
+    return nil
+end
+
+
+function _M.reset(self)
+    return C.HMAC_Init_ex(self._ctx, nil, 0, nil, nil) == 1
+end
+
+return _M

--- a/nginx-cache-path.conf
+++ b/nginx-cache-path.conf
@@ -1,1 +1,0 @@
-proxy_cache_path   /tmp/ levels=1:2 keys_zone=s3_cache:10m max_size=500m;

--- a/nginx-site-example.conf
+++ b/nginx-site-example.conf
@@ -1,99 +1,68 @@
-server {
-    listen       80;
-    server_name  localhost;
 
-    #charset koi8-r;
-    access_log  /var/log/nginx/host.access.log  main;
-    error_log   /var/log/nginx/host.error.log warn;
+# Copyright (C) 2020  Axel Amigo Arnold
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+server {
+    listen 80;
+    server_tokens off;
+    server_name _;
+    set $bucket_region 'your-bucket-region';
+    set $bucket_name 'your-bucket-name';
+    set $s3_host $bucket_name.s3.$bucket_region.amazonaws.com;
+    access_log /tmp/access.log;
+    error_log /tmp/error.log warn;
+
+    # Rename this location to one of your choice
+    location ~ /s/ {
+        secure_link $arg_md5,$arg_expires;
+
+        # Rename "AM1ghtyS3cr3t!" with a secret of your choice
+        secure_link_md5 "$secure_link_expires$uri$remote_addr AM1ghtyS3cr3t!";
+
+        if ($secure_link = "") {
+        return 403;
+        }
+
+        if ($secure_link = "0") {
+        return 410;
+        }
+
+        rewrite ^/s/(.*)?.*$ /$1;
+    }
 
     location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-    }
+        internal;
+        resolver        127.0.0.1 local=on valid=300s;
+        resolver_timeout 10s;
 
-	# Rename this location to one of your choice
-    location /s/ {
-        secure_link $arg_md5,$arg_expires;
-		# Rename "AM1ghtyS3cr3t!" with a secret of your choice
-        secure_link_md5 "$secure_link_expires$uri$remote_addr AM1ghtyS3cr3t!";
-
-        if ($secure_link = "") {
-            return 403;
+        # Sign AWS request using
+        # AWS Signature Version 4
+        # https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+        access_by_lua_block {
+            require("resty.aws").s3_set_headers(ngx.var.s3_host, ngx.var.uri)
         }
-
-        if ($secure_link = "0") {
-            return 410;
-        }
-
-        rewrite ^/s/(.*)$ /s3/$1;
-    }
-
-	# Rename this location to one of your choice
-    location /s/cached/ {
-        secure_link $arg_md5,$arg_expires;
-		# Rename "AM1ghtyS3cr3t!" with a secret of your choice
-        secure_link_md5 "$secure_link_expires$uri$remote_addr AM1ghtyS3cr3t!";
-
-        if ($secure_link = "") {
-            return 403;
-        }
-
-        if ($secure_link = "0") {
-            return 410;
-        }
-
-        #rewrite ^ /s3/$secure_link;
-        rewrite ^/s/cached/(.*)$ /s3_cached/$1;
-    }
-
-    location /s3/ {
-      internal;
-      proxy_http_version     1.1;
-      proxy_set_header       Connection "";
-      proxy_set_header       Authorization '';
-      proxy_set_header       Host your-bucket;
-      proxy_hide_header      x-amz-id-2;
-      proxy_hide_header      x-amz-request-id;
-      proxy_hide_header      x-amz-meta-server-side-encryption;
-      proxy_hide_header      x-amz-server-side-encryption;
-      proxy_hide_header      Set-Cookie;
-      proxy_ignore_headers   Set-Cookie;
-      proxy_intercept_errors on;
-      add_header             Cache-Control max-age=31536000;
-      proxy_pass             https://your-bucket/;
-    }
-
-    location /s3_cached/ {
-      internal;
-      proxy_cache            s3_cache;
-      proxy_http_version     1.1;
-      proxy_set_header       Connection "";
-      proxy_set_header       Authorization '';
-      proxy_set_header       Host your-bucket;
-      proxy_hide_header      x-amz-id-2;
-      proxy_hide_header      x-amz-request-id;
-      proxy_hide_header      x-amz-meta-server-side-encryption;
-      proxy_hide_header      x-amz-server-side-encryption;
-      proxy_hide_header      Set-Cookie;
-      proxy_ignore_headers   Set-Cookie;
-      proxy_cache_revalidate on;
-      proxy_intercept_errors on;
-      proxy_cache_use_stale  error timeout updating http_500 http_502 http_503 http_504;
-      proxy_cache_lock       on;
-      proxy_cache_valid      200 304 60m;
-      add_header             Cache-Control max-age=31536000;
-      add_header             X-Cache-Status $upstream_cache_status;
-      proxy_pass             https://your-bucket/;
-    }
-
-    error_page  404              /404.html;
-
-    # redirect server error pages to the static page /50x.html
-    #
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
+        proxy_http_version     1.1;
+        proxy_hide_header      x-amz-id-2;
+        proxy_hide_header      x-amz-request-id;
+        proxy_hide_header      x-amz-meta-server-side-encryption;
+        proxy_hide_header      x-amz-server-side-encryption;
+        proxy_hide_header      Set-Cookie;
+        proxy_ignore_headers   Set-Cookie;
+        proxy_intercept_errors on;
+        add_header             Cache-Control max-age=31536000;
+        proxy_pass https://$s3_host$uri;
     }
 
 }
-

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,68 @@
+# nginx.conf  --  docker-openresty
+#
+# This file is installed to:
+#   `/usr/local/openresty/nginx/conf/nginx.conf`
+# and is the file loaded by nginx at startup,
+# unless the user specifies otherwise.
+#
+# It tracks the upstream OpenResty's `nginx.conf`, but removes the `server`
+# section and adds this directive:
+#     `include /etc/nginx/conf.d/*.conf;`
+#
+# The `docker-openresty` file `nginx.vh.default.conf` is copied to
+# `/etc/nginx/conf.d/default.conf`.  It contains the `server section
+# of the upstream `nginx.conf`.
+#
+# See https://github.com/openresty/docker-openresty/blob/master/README.md#nginx-config-files
+#
+
+#user  nobody;
+worker_processes  1;
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+#pid        logs/nginx.pid;
+
+env AWS_ACCESS_KEY_ID=INVALID_AWS_ACCESS_KEY_ID;
+env AWS_SECRET_ACCESS_KEY=INVALID_AWS_SECRET_ACCESS_KEY;
+
+error_log  /dev/fd/1 warn;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    #                  '$status $body_bytes_sent "$http_referer" '
+    #                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+    #access_log  logs/access.log  main;
+    access_log  /dev/stdout;
+
+
+    # See Move default writable paths to a dedicated directory (#119)
+    # https://github.com/openresty/docker-openresty/issues/119
+    client_body_temp_path /var/run/openresty/nginx-client-body;
+    proxy_temp_path       /var/run/openresty/nginx-proxy;
+    fastcgi_temp_path     /var/run/openresty/nginx-fastcgi;
+    uwsgi_temp_path       /var/run/openresty/nginx-uwsgi;
+    scgi_temp_path        /var/run/openresty/nginx-scgi;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/secret-link-generator.py
+++ b/secret-link-generator.py
@@ -1,5 +1,22 @@
 #!/usr/bin/env python3
 
+"""
+Copyright (C) 2020  Axel Amigo Arnold
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
 from datetime import datetime, timedelta, timezone
 from base64 import b64encode
 import hashlib
@@ -45,7 +62,7 @@ def generate_link(path, remote_address, host_url, secret, expiration_timestamp):
     Generates a link that expires.
 
     Example:
-      ./link-generator-example.py -p /s/file.tar.gz -r 172.17.0.1 -h http://localhost:9090 -s changeme
+      ./secret-link-generator.py -p /s/file.tar.gz -r 172.17.0.1 -h http://localhost:9090 -s changeme
     """
     forge_link(path.encode(), remote_address.encode(), secret.encode(), host_url.encode(), expiration_timestamp.encode())
 


### PR DESCRIPTION
We had to change the Docker image from NGINX:alpine
to OpenResty:buster to be able to do some LUA scripting
in order to sign AWS requests.

The cache site was not migrated: to be done in a
separate issue.